### PR TITLE
Store player name in a cookie

### DIFF
--- a/backend/src/main/kotlin/com/game/main/Main.kt
+++ b/backend/src/main/kotlin/com/game/main/Main.kt
@@ -58,7 +58,7 @@ fun createNewGame(): Response {
     GameRepository.createGame(gameId, game)
     return Response(Status.SEE_OTHER)
         .header("Location", "/lobby/$gameId")
-        .cookie(Cookie("game_host", gameId, path = "/"))
+        .cookie(Cookie("${gameId}_host", "1", path = "/"))
 }
 
 fun startGameHandler(req: Request, websocket: GameWebSocket): Response {
@@ -83,4 +83,5 @@ fun joinGameHandler(req: Request, websocket: GameWebSocket): Response {
     val isStarted = game.isStarted()
     val responseBody = JoinGameResponse(gameId, game.hostId, game.playerListForSerialization(), isStarted)
     return Response(OK).body(Jackson.asInputStream(responseBody))
+        .cookie(Cookie(gameId, username, path = "/"))
 }

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,5 +1,5 @@
 # Deploy hit-or-miss
 
-Deployment needs to be done by Rob because it lives in his fly.io personal organisation.
+Deployment needs to be done by Rob because it's hosted in his fly.io personal organisation.
 
 Run `./gradlew :deployment:flyDeploy`

--- a/frontend/src/components/Game.test.js
+++ b/frontend/src/components/Game.test.js
@@ -105,7 +105,7 @@ test('renders scoreboard with all player names', async () => {
   renderGame()
 
   expectScoreboardRows([
-    {player: "Alice", score: "0"},
+    {player: "Alice (you)", score: "0"},
     {player: "Bob", score: "0"},
     {player: "Charlie", score: "0"},
   ])
@@ -206,7 +206,7 @@ test('scoreboard updates after hit or miss selection', async () => {
   ])
 
   expectScoreboardRows([
-    {player: "Alice", score: "1"},
+    {player: "Alice (you)", score: "1"},
     {player: "Bob", score: "1"},
     {player: "Charlie", score: "0"}
   ])

--- a/frontend/src/components/GameContext.js
+++ b/frontend/src/components/GameContext.js
@@ -6,7 +6,7 @@ export default function GameContext() {
   const location = useLocation();
   const clientUsername = location.state.clientUsername;
   const initialPlayer = location.state.currentPlayer;
-  const playerNames = location.state.playerNames
+  const playerNames = location.state.playerNames;
 
   return <Game gameId={gameId} clientUsername={clientUsername} initialPlayer={initialPlayer} playerNames={playerNames}/>
 }


### PR DESCRIPTION
Part 1 of https://github.com/codeday-hom/hit-or-miss/issues/42

### Changes

Copied from the commit message of 5f7ec5b7aab2c7caebeacc37eb17b25f4e70bdf4:

- Store player name in a cookie. This makes it possible to refresh the lobby and still retain your identity in the lobby and the ensuing game once it is started.
- Also, use a different scheme for storing the host marker cookie to make it more tied to the particular game they are the host of.
- Improve variable names in Lobby and generally do some polishing of it.
- Don't show the "Your name:" bit until a player has entered their name, to avoid confusion.
- Added a couple of missing tests for the lobby regarding the state of the Start Game button.

Also:

- Fixed a test for a change I made earlier.
- A minor formatting fix for a change I made earlier.